### PR TITLE
Ensure proper highlighting of legal Clojure symbols

### DIFF
--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -70,7 +70,7 @@ syntax match clojureDeref "@"
 syntax match clojureAnonArg "%\([12][0-9]\|[1-9]\|&\)\?"
 syntax match clojureDispatch "\v#[\^'=<_]?"
 
-syntax match clojureSymbol "\v[a-zA-Z!$&*_+=|<.>?-]+(:?[a-zA-Z0-9!#$&*_+=|'<.>?-])*[#:]@<!"
+syntax match clojureSymbol "\v([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+(:?([a-zA-Z0-9!#$&*_+=|'<.>?-]|[^\x00-\x7F]))*[#:]@<!"
 
 syntax region clojureRegexp start=/L\=\#"/ skip=/\\\\\|\\"/ end=/"/
 


### PR DESCRIPTION
This patch fixes highlighting of Clojure symbols that involve characters such as `'`, `#`, and `:`.

Previously a symbol like `super:hero` would incorrectly treat the `:hero` portion of the symbol as a `clojureKeyword`. Also if a symbol contained a `'` or `#` character it would be highlighted. In addition to this observation, if the `'` or `#` were followed by a keyword, it would be highlighted as well. So the symbol `burger'time` would produce the synIDs `clojureSexp`, `clojureQuote`, and `clojureMacro` respectively.

Here is a screenshot of this behavior prior to this patch:

![Before](https://f.cloud.github.com/assets/541996/230335/17d5090a-86bd-11e2-8d57-fb29d6791b15.png)

And after:

![After](https://f.cloud.github.com/assets/541996/230316/7584e8a0-86bc-11e2-9dc2-7b9efbb7adbd.png)

I must admit I am a bit of a novice when it comes to working on these sorts of files, but I thought this would be the best way to get a conversation going about how to resolve this issue. If it's not up to snuff let me know what I can do to make it better.

Thanks!
