### PR TITLE
Allow for highlighting of escape characters contained within clojureString.

### DIFF
--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -75,8 +75,6 @@ syntax match clojureAnonArg "%\(20\|1\d\|[1-9]\|&\)\?"
 
 syntax match clojureSymbol "\v([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+(:?([a-zA-Z0-9!#$%&*_+=|'<.>?-]|[^\x00-\x7F]))*[#:]@<!"
 
-syntax region clojureRegexp start=/L\=\#"/ skip=/\\\\\|\\"/ end=/"/
-
 syntax match clojureComment ";.*$" contains=clojureTodo,@Spell
 syntax match clojureComment "#!.*$"
 


### PR DESCRIPTION
A number of syntax files provide this and it's something I find useful and visually appealing when working with strings.

I've also, updated `clojureCharacter` to support all unicode values (hex).
