### PR TITLE
Add spellcheck in strings.  Particularly helpful for docstrings.

### DIFF
--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -38,7 +38,7 @@ syntax match clojureKeyword "\v<:{1,2}%([^ \n\r\t()\[\]{}";@^`~\\%/]+/)*[^ \n\r\
 
 syntax match clojureStringEscape "\v\\%([\\btnfr"]|u\x{4}|[0-3]\o{2}|\o{1,2})" contained
 
-syntax region clojureString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=clojureStringEscape
+syntax region clojureString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=clojureStringEscape,@Spell
 
 syntax match clojureCharacter "\\."
 syntax match clojureCharacter "\\o\%([0-3]\o\{2\}\|\o\{1,2\}\)"


### PR DESCRIPTION
Spellcheck is currently only enabled for comments from issue https://github.com/guns/vim-clojure-static/issues/10 .  Most of my spelling errors happen in docstrings, though.  This patch adds @Spell to all clojure strings.  I don't think there is a distinction between docstrings and regular strings in the syntax config, so this enables spellcheck on all strings.

Let me know if you have any questions.  Thanks.
