### PR TITLE
Ignore tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Useful when generating documentation for bundled plugins stored as Git submodules.
