### PR TITLE
Add fold arguments to appropriate syntax forms

### DIFF
--- a/doc/clojure.txt
+++ b/doc/clojure.txt
@@ -123,6 +123,17 @@ This option is off by default.
 	" Default
 	let g:clojure_align_subforms = 0
 <
+							*g:clojure_fold*
+
+Setting this option enables folding Clojure code via syntax forms. Any list,
+vector, or map that extends over more than one line can be folded using the
+standard Vim |fold-commands|.
+
+This option is off by default.
+>
+	" Default
+	let g:clojure_fold = 0
+<
 
 ABOUT							*clojure-about*
 

--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -15,6 +15,10 @@ if exists("b:current_syntax")
 	finish
 endif
 
+if has("folding") && exists("g:clojure_fold")
+	setlocal foldmethod=syntax
+endif
+
 " Generated from https://github.com/guns/vim-clojure-static/blob/%%RELEASE_TAG%%/clj/src/vim_clojure_static/generate.clj
 " Clojure version 1.5.1
 syntax keyword clojureConstant nil
@@ -117,9 +121,9 @@ syntax keyword clojureCommentTodo contained FIXME XXX TODO FIXME: XXX: TODO:
 syntax match clojureComment ";.*$" contains=clojureCommentTodo,@Spell
 syntax match clojureComment "#!.*$"
 
-syntax region clojureSexp   matchgroup=clojureParen start="("  matchgroup=clojureParen end=")" contains=TOP,@Spell
-syntax region clojureVector matchgroup=clojureParen start="\[" matchgroup=clojureParen end="]" contains=TOP,@Spell
-syntax region clojureMap    matchgroup=clojureParen start="{"  matchgroup=clojureParen end="}" contains=TOP,@Spell
+syntax region clojureSexp   matchgroup=clojureParen start="("  matchgroup=clojureParen end=")" contains=TOP,@Spell fold
+syntax region clojureVector matchgroup=clojureParen start="\[" matchgroup=clojureParen end="]" contains=TOP,@Spell fold
+syntax region clojureMap    matchgroup=clojureParen start="{"  matchgroup=clojureParen end="}" contains=TOP,@Spell fold
 
 " Highlight superfluous closing parens, brackets and braces.
 syntax match clojureError "]\|}\|)"


### PR DESCRIPTION
This change makes it so that setting `foldmethod` to `syntax` allows you to
fold up Clojure S-Exps.
