### PR TITLE
Clojure syntax can't be used with :syntax include

### DIFF
--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -19,6 +19,10 @@ if has("folding") && exists("g:clojure_fold") && g:clojure_fold > 0
 	setlocal foldmethod=syntax
 endif
 
+setlocal iskeyword+=?,-,*,!,+,/,=,<,>,.,:,$
+
+syntax cluster clojureTop contains=clojureAnonArg,clojureBoolean,clojureCharacter,clojureComment,clojureCond,clojureConstant,clojureDefine,clojureDeref,clojureDispatch,clojureError,clojureException,clojureFunc,clojureKeyword,clojureMacro,clojureMap,clojureMeta,clojureNumber,clojureQuote,clojureRegexp,clojureRepeat,clojureSexp,clojureSpecial,clojureString,clojureSymbol,clojureUnquote,clojureVarArg,clojureVariable,clojureVector
+
 " Generated from https://github.com/guns/vim-clojure-static/blob/%%RELEASE_TAG%%/clj/src/vim_clojure_static/generate.clj
 " Clojure version 1.5.1
 syntax keyword clojureConstant nil
@@ -53,6 +57,7 @@ syntax match clojureCharacter "\\newline"
 syntax match clojureCharacter "\\return"
 syntax match clojureCharacter "\\backspace"
 syntax match clojureCharacter "\\formfeed"
+
 
 syntax match clojureSymbol "\v%([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+%(:?%([a-zA-Z0-9!#$%&*_+=|'<.>/?-]|[^\x00-\x7F]))*[#:]@<!"
 
@@ -121,9 +126,9 @@ syntax keyword clojureCommentTodo contained FIXME XXX TODO FIXME: XXX: TODO:
 syntax match clojureComment ";.*$" contains=clojureCommentTodo,@Spell
 syntax match clojureComment "#!.*$"
 
-syntax region clojureSexp   matchgroup=clojureParen start="("  matchgroup=clojureParen end=")" contains=TOP,@Spell fold
-syntax region clojureVector matchgroup=clojureParen start="\[" matchgroup=clojureParen end="]" contains=TOP,@Spell fold
-syntax region clojureMap    matchgroup=clojureParen start="{"  matchgroup=clojureParen end="}" contains=TOP,@Spell fold
+syntax region clojureSexp   matchgroup=clojureParen start="("  matchgroup=clojureParen end=")" contains=@clojureTop fold
+syntax region clojureVector matchgroup=clojureParen start="\[" matchgroup=clojureParen end="]" contains=@clojureTop fold
+syntax region clojureMap    matchgroup=clojureParen start="{"  matchgroup=clojureParen end="}" contains=@clojureTop fold
 
 " Highlight superfluous closing parens, brackets and braces.
 syntax match clojureError "]\|}\|)"


### PR DESCRIPTION
Hi!

I tried embedding the Clojure syntax highlighting in another syntax, but it doesn't work. I'm doing the following (simplified for the pull request):

``````
syntax include @Clojure syntax/clojure.vim
syntax region clojureCode matchgroup=clojureCodeDelimiter start=/^```clojure$/ end=/^```$/ contains=@Clojure
``````

As fair as I understand it, this is the standard way of doing it, but it does not highlight properly. The culprit are the following three lines:

```
syntax region clojureSexp   matchgroup=clojureParen start="("  matchgroup=clojureParen end=")" contains=TOP,@Spell fold
syntax region clojureVector matchgroup=clojureParen start="\[" matchgroup=clojureParen end="]" contains=TOP,@Spell fold
syntax region clojureMap    matchgroup=clojureParen start="{"  matchgroup=clojureParen end="}" contains=TOP,@Spell fold
```

Since they do `contains=TOP`, Vim attempts to match all top-level rules, not just the Clojure ones.

Aggregating them in a cluster and using it instead (as the [HTML syntax](https://code.google.com/p/vim/source/browse/runtime/syntax/html.vim#123) does) solves the problem.

Because the syntax rules depend on the `iskeyword` option, I have copied it from the ftplugin, as the Vim manual suggests ([section 44.2](http://vimdoc.sourceforge.net/htmldoc/usr_44.html#44.2), under 'UNUSUAL KEYWORDS').

I hope this makes sense :)
