### PR TITLE
Attempt to avoid errors on aliased 'contains'

### DIFF
--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -35,9 +35,18 @@ let s:clojure_syntax_keywords = {
     \ , 'clojureVariable': ["*1","*2","*3","*agent*","*allow-unresolved-vars*","*assert*","*clojure-version*","*command-line-args*","*compile-files*","*compile-path*","*compiler-options*","*data-readers*","*default-data-reader-fn*","*e","*err*","*file*","*flush-on-newline*","*fn-loader*","*in*","*math-context*","*ns*","*out*","*print-dup*","*print-length*","*print-level*","*print-meta*","*print-readably*","*read-eval*","*source-path*","*unchecked-math*","*use-context-classloader*","*verbose-defrecords*","*warn-on-reflection*","EMPTY-NODE","char-escape-string","char-name-string","clojure.core/*1","clojure.core/*2","clojure.core/*3","clojure.core/*agent*","clojure.core/*allow-unresolved-vars*","clojure.core/*assert*","clojure.core/*clojure-version*","clojure.core/*command-line-args*","clojure.core/*compile-files*","clojure.core/*compile-path*","clojure.core/*compiler-options*","clojure.core/*data-readers*","clojure.core/*default-data-reader-fn*","clojure.core/*e","clojure.core/*err*","clojure.core/*file*","clojure.core/*flush-on-newline*","clojure.core/*fn-loader*","clojure.core/*in*","clojure.core/*math-context*","clojure.core/*ns*","clojure.core/*out*","clojure.core/*print-dup*","clojure.core/*print-length*","clojure.core/*print-level*","clojure.core/*print-meta*","clojure.core/*print-readably*","clojure.core/*read-eval*","clojure.core/*source-path*","clojure.core/*unchecked-math*","clojure.core/*use-context-classloader*","clojure.core/*verbose-defrecords*","clojure.core/*warn-on-reflection*","clojure.core/EMPTY-NODE","clojure.core/char-escape-string","clojure.core/char-name-string","clojure.core/default-data-readers","clojure.core/primitives-classnames","clojure.core/unquote","clojure.core/unquote-splicing","default-data-readers","primitives-classnames","unquote","unquote-splicing"]
     \ }
 
+let s:keyword_reserved_words = ["contains", "oneline", "concealends"]
+let s:keyword_reserved_re    = "'" . '\<\(' . join(s:keyword_reserved_words, '\|') . '\)\>' . "'"
+
 function! s:syntax_keyword(dict)
 	for key in keys(a:dict)
-		execute 'syntax keyword' key join(a:dict[key], ' ')
+		let filtered = filter(copy(a:dict[key]), 'v:val !~ ' . s:keyword_reserved_re)
+		execute 'syntax keyword' key join(filtered, ' ')
+
+		let removed  = filter(copy(a:dict[key]), 'v:val =~ ' . s:keyword_reserved_re)
+		if len(removed)
+			execute 'syntax match' key '+\<\('.join(removed, '\|').'\)\>+'
+		endif
 	endfor
 endfunction
 


### PR DESCRIPTION
Users with vim-clojure-static and vim-clojure-highlight see errors and broken highlighting when opening some test files. The culprit is `[midje.sweet :refer :all]` as that includes a function `contains`. And this is illegal in Vim:

``` vim
syntax keyword clojureFunc foo contains bar
" E395: contains argument not accepted here
```

Similarly a couple of other words (oneline, concealends) will not be recognised; but I'd be very surprised if they turned up in much code!

Note that my example code attached still doesn't highlight 'contains' correctly - for the life of me I can't figure out why as the regular expression generated appears under clojureFunc when I call `:syntax` and pasting that regexp into a manual `:syntax match` is fine.
