### PR TITLE
Ignore help tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Prevents "untracked content" warning if installed via `pathogen.vim` as a submodule of a dotfiles repo.