### PR TITLE
Add indent special case for Reader Conditionals

### DIFF
--- a/clj/dev-resources/test-reader-conditional-indent.in
+++ b/clj/dev-resources/test-reader-conditional-indent.in
@@ -1,0 +1,10 @@
+(def DateTime #?(:clj org.joda.time.DateTime,
+                      :cljs goog.date.UtcDateTime))
+
+#?(:cljs
+    (extend-protocol ToDateTime
+      goog.date.Date
+      (-to-date-time [x]
+        (goog.date.UtcDateTime. (.getYear x) (.getMonth x) (.getDate x)))))
+
+;; vim:ft=clojure:

--- a/clj/dev-resources/test-reader-conditional-indent.out
+++ b/clj/dev-resources/test-reader-conditional-indent.out
@@ -1,0 +1,10 @@
+(def DateTime #?(:clj org.joda.time.DateTime,
+                 :cljs goog.date.UtcDateTime))
+
+#?(:cljs
+   (extend-protocol ToDateTime
+     goog.date.Date
+     (-to-date-time [x]
+       (goog.date.UtcDateTime. (.getYear x) (.getMonth x) (.getDate x)))))
+
+;; vim:ft=clojure:

--- a/clj/test/vim_clojure_static/indent_test.clj
+++ b/clj/test/vim_clojure_static/indent_test.clj
@@ -23,3 +23,8 @@
                :in "test-side-effects-in-indentexpr.in"
                :out "test-side-effects-in-indentexpr.out"
                :keys "/α\\<CR>:call GetClojureIndent()\\<CR>rxj:call GetClojureIndent()\\<CR>ry"))
+
+(deftest test-reader-conditional-indent
+  (test-indent "is inherited from previous element"
+               :in "test-reader-conditional-indent.in"
+               :out "test-reader-conditional-indent.out"))

--- a/indent/clojure.vim
+++ b/indent/clojure.vim
@@ -187,6 +187,16 @@ if exists("*searchpairpos")
 		return val
 	endfunction
 
+	" Check if form is a reader conditional, that is, it is prefixed by #?
+	" or @#?
+	function! s:is_reader_conditional_special_case(position)
+		if getline(a:position[0])[a:position[1] - 3 : a:position[1] - 2] == "#?"
+			return 1
+		endif
+
+		return 0
+	endfunction
+
 	" Returns 1 for opening brackets, -1 for _anything else_.
 	function! s:bracket_type(char)
 		return stridx('([{', a:char) > -1 ? 1 : -1
@@ -252,6 +262,10 @@ if exists("*searchpairpos")
 
 		if s:is_method_special_case(paren)
 			return [paren[0], paren[1] + &shiftwidth - 1]
+		endif
+
+		if s:is_reader_conditional_special_case(paren)
+			return paren
 		endif
 
 		" In case we are at the last character, we use the paren position.


### PR DESCRIPTION
Currently reader conditionals are indented like function calls, but instead I think they should be intended like vectors and maps:

```clj
;; Current
(def DateTime #?(:clj org.joda.time.DateTime,
                      :cljs goog.date.UtcDateTime))

;; Correct
(def DateTime #?(:clj org.joda.time.DateTime,
                 :cljs goog.date.UtcDateTime))

;; Current
#?(:cljs
    (extend-protocol ToDateTime
      goog.date.Date
      (-to-date-time [x]
        (goog.date.UtcDateTime. (.getYear x) (.getMonth x) (.getDate x)))))

;; Correct
#?(:cljs
   (extend-protocol ToDateTime
     goog.date.Date
     (-to-date-time [x]
       (goog.date.UtcDateTime. (.getYear x) (.getMonth x) (.getDate x)))))
```

Implemented by just looking at previous two chars before parentheses. This wont support cases where reader conditional is not on the same line as parentheses, but I don't think that is a problem.