### PR TITLE
remove extra char

### DIFF
--- a/indent/clojure.vim
+++ b/indent/clojure.vim
@@ -121,7 +121,7 @@ if exists("*searchpairpos")
 			if s:syn_id_name() !~? "string"
 				return -1
 			endif
-			if s:current_char() != '\\'
+			if s:current_char() != '\'
 				return -1
 			endif
 			call cursor(0, col("$") - 1)


### PR DESCRIPTION
backslashes don't need to be escaped in single quotes, otherwise this will never equal 1 char which s:current_char returns. also, I don't write clojure but this script is a great reference, thanks