### PR TITLE
Add indent special case for dispatch macro, #

### DIFF
--- a/clj/dev-resources/test-dispatch-macro-indent.in
+++ b/clj/dev-resources/test-dispatch-macro-indent.in
@@ -1,0 +1,31 @@
+(#(foo)
+bar)
+
+(#(foo
+bar))
+
+(#(foo bar
+a))
+
+(#(foo bar)
+a)
+
+(#{foo}
+bar)
+
+(#{foo
+bar})
+
+(#{foo bar}
+a)
+
+(#_(foo)
+bar)
+
+(#_(foo
+bar))
+
+(#_(foo bar)
+a)
+
+;; vim:ft=clojure:

--- a/clj/dev-resources/test-dispatch-macro-indent.out
+++ b/clj/dev-resources/test-dispatch-macro-indent.out
@@ -1,0 +1,31 @@
+(#(foo)
+  bar)
+
+(#(foo
+    bar))
+
+(#(foo bar
+       a))
+
+(#(foo bar)
+  a)
+
+(#{foo}
+  bar)
+
+(#{foo
+   bar})
+
+(#{foo bar}
+  a)
+
+(#_(foo)
+ bar)
+
+(#_(foo
+     bar))
+
+(#_(foo bar)
+ a)
+
+;; vim:ft=clojure:

--- a/clj/test/vim_clojure_static/indent_test.clj
+++ b/clj/test/vim_clojure_static/indent_test.clj
@@ -28,3 +28,8 @@
   (test-indent "reader conditionals are indented like maps"
                :in "test-reader-conditional-indent.in"
                :out "test-reader-conditional-indent.out"))
+
+(deftest test-dispatch-macro-indent
+  (test-indent "dispatch macro indentation is handled correctly"
+               :in "test-dispatch-macro-indent.in"
+               :out "test-dispatch-macro-indent.out"))

--- a/indent/clojure.vim
+++ b/indent/clojure.vim
@@ -196,6 +196,27 @@ if exists("*searchpairpos")
 
 		return 0
 	endfunction
+	
+	" Check if keyword is an anonymous function, prefixed by #(, or a set,
+	" prefixed by #{
+	function! s:is_anonymous_function_or_set(word)
+		if a:word[0:1] == "#("
+			return 1
+		elseif a:word[0:1] == "#{"
+			return 1
+		endif
+
+		return 0
+	endfunction
+
+	" Check if keyword is ignored, that is, prefixed by #_
+	function! s:is_ignored(word)
+		if a:word[0:1] == "#_"
+			return 1
+		endif
+
+		return 0
+	endfunction
 
 	" Returns 1 for opening brackets, -1 for _anything else_.
 	function! s:bracket_type(char)
@@ -290,6 +311,18 @@ if exists("*searchpairpos")
 		let w = s:current_word()
 		if s:bracket_type(w[0]) == 1
 			return paren
+		endif
+
+		" If the keyword begins with #, check if it is an anonymous
+		" function or set, in which case we indent by the shiftwidth
+		" (minus one if g:clojure_align_subforms = 1), or if it is
+		" ignored, in which case we use the ( position for indent.
+		if w[0] == "#"
+			if s:is_anonymous_function_or_set(w)
+				return [paren[0], paren[1] + (g:clojure_align_subforms ? 0 : &shiftwidth - 1)]
+			elseif s:is_ignored(w)
+				return paren
+			endif
 		endif
 
 		" Test words without namespace qualifiers and leading reader macro


### PR DESCRIPTION
The dispatch macro `#` causes some incorrect indent behavior, in particular when the first form in an s-expression begins with `#`:

```clojure
;; Current
(#(foo bar)
       baz)

(#{foo bar}
       baz)

(#_(foo bar)
        baz)

(#_(foo)
  bar)

;; Correct
(#(foo bar)
  baz)

(#{foo bar}
  baz)

(#_(foo bar)
 baz)

(#_(foo)
 bar)
```

Currently, the first character of the keyword after the opening `(` is checked to determine if the keyword is an s-expression, missing these cases.  This addition checks the first character to see if it is `#`, in which case it checks the second character to catch these cases.